### PR TITLE
Ft numberic compare

### DIFF
--- a/expression/eval/compare.go
+++ b/expression/eval/compare.go
@@ -345,6 +345,17 @@ func compare(obj1, obj2 interface{}, kind reflect.Kind) (CompareType, bool) {
 	return compareEqual, false
 }
 
+// ValueEquals asserts that the first element is value-equal to the second
+// only care about the value, will cast the type to the same type before do compare
+//
+//    assert.ValueEquals(t, 2, 1)
+//    assert.ValueEquals(t, 2, float64(2.0))
+//    assert.ValueEquals(t, "b", "a")
+// it's different to the `Equals` which use reflect.DeepEqual will check the type and value are the same
+func ValueEquals(e1 interface{}, e2 interface{}) bool {
+	return compareTwoValues(e1, e2, []CompareType{compareEqual})
+}
+
 // Greater asserts that the first element is greater than the second
 //
 //    assert.Greater(t, 2, 1)

--- a/expression/eval/compare.go
+++ b/expression/eval/compare.go
@@ -409,22 +409,23 @@ func LessOrEqual(e1 interface{}, e2 interface{}) bool {
 // float32     the set of all IEEE-754 32-bit floating-point numbers
 // float64     the set of all IEEE-754 64-bit floating-point numbers
 
-func isNumberTypes(i interface{}) bool {
-	switch i.(type) {
-	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64, float32, float64:
+func isNumberKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Int64, reflect.Float64, reflect.Int, reflect.Float32, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Int8, reflect.Int16, reflect.Int32:
 		return true
 	default:
 		return false
 	}
 }
 
-func isFloatType(i interface{}) bool {
-	switch i.(type) {
-	case float32, float64:
+func isFloatKind(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Float64, reflect.Float32:
 		return true
 	default:
 		return false
 	}
+
 }
 
 func toInt64(i interface{}) (int64, error) {
@@ -534,8 +535,8 @@ func compareTwoValues(e1 interface{}, e2 interface{}, allowedComparesResults []C
 	// here, we support number types: int64/float64 compare
 	// check and cast to same type: int64 or float64 and do compare later
 	// but, here got a precision lost, which may case the eval result wrong
-	if e1Kind != e2Kind && isNumberTypes(e1) && isNumberTypes(e2) {
-		if isFloatType(e1) || isFloatType(e2) {
+	if e1Kind != e2Kind && isNumberKind(e1Kind) && isNumberKind(e2Kind) {
+		if isFloatKind(e1Kind) || isFloatKind(e2Kind) {
 			// both cast to float64
 			newE1, err := toFloat64(e1)
 			if err == nil {
@@ -548,6 +549,7 @@ func compareTwoValues(e1 interface{}, e2 interface{}, allowedComparesResults []C
 				e2Kind = reflect.Float64
 			}
 		} else {
+			// both cast to int64
 			newE1, err := toInt64(e1)
 			if err == nil {
 				e1 = newE1

--- a/expression/eval/compare.go
+++ b/expression/eval/compare.go
@@ -38,7 +38,10 @@
 package eval
 
 import (
+	"encoding/json"
+	"fmt"
 	"reflect"
+	"strings"
 )
 
 // github.com/stretchr/testify/assert/assertion_compare.go
@@ -380,10 +383,173 @@ func LessOrEqual(e1 interface{}, e2 interface{}) bool {
 	return compareTwoValues(e1, e2, []CompareType{compareLess, compareEqual})
 }
 
-func compareTwoValues(e1 interface{}, e2 interface{}, allowedComparesResults []CompareType) bool {
+// the max precision is int64, so uint64 not supported => or only part of uint64 supported?
 
+// uint8       the set of all unsigned  8-bit integers (0 to 255)
+// uint16      the set of all unsigned 16-bit integers (0 to 65535)
+// uint32      the set of all unsigned 32-bit integers (0 to 4294967295)
+// uint64      the set of all unsigned 64-bit integers (0 to 18446744073709551615)
+//
+// int8        the set of all signed  8-bit integers (-128 to 127)
+// int16       the set of all signed 16-bit integers (-32768 to 32767)
+// int32       the set of all signed 32-bit integers (-2147483648 to 2147483647)
+// int64       the set of all signed 64-bit integers (-9223372036854775808 to 9223372036854775807)
+
+// float32     the set of all IEEE-754 32-bit floating-point numbers
+// float64     the set of all IEEE-754 64-bit floating-point numbers
+
+func isNumberTypes(i interface{}) bool {
+	switch i.(type) {
+	case uint, uint8, uint16, uint32, uint64, int, int8, int16, int32, int64, float32, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func isFloatType(i interface{}) bool {
+	switch i.(type) {
+	case float32, float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func toInt64(i interface{}) (int64, error) {
+	switch s := i.(type) {
+	case int:
+		return int64(s), nil
+	case int64:
+		return s, nil
+	case int32:
+		return int64(s), nil
+	case int16:
+		return int64(s), nil
+	case int8:
+		return int64(s), nil
+	case uint:
+		return int64(s), nil
+	case uint64:
+		// NOTE: precision lost
+		return int64(s), nil
+	case uint32:
+		return int64(s), nil
+	case uint16:
+		return int64(s), nil
+	case uint8:
+		return int64(s), nil
+		// NOTE: only cast between int*, no float32/float64
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T to int64", i, i)
+	}
+}
+
+func toFloat64(i interface{}) (float64, error) {
+	switch s := i.(type) {
+	case float64:
+		return s, nil
+	case float32:
+		return float64(s), nil
+	case int:
+		return float64(s), nil
+	case int64:
+		// NOTE: precision lost
+		return float64(s), nil
+	case int32:
+		return float64(s), nil
+	case int16:
+		return float64(s), nil
+	case int8:
+		return float64(s), nil
+	case uint:
+		return float64(s), nil
+	case uint64:
+		// NOTE: precision lost
+		return float64(s), nil
+	case uint32:
+		return float64(s), nil
+	case uint16:
+		return float64(s), nil
+	case uint8:
+		return float64(s), nil
+	default:
+		return 0, fmt.Errorf("unable to cast %#v of type %T to float64", i, i)
+	}
+}
+
+func castJsonNumber(i interface{}) (interface{}, reflect.Kind, error) {
+	n, ok := i.(json.Number)
+	if !ok {
+		return nil, reflect.Invalid, fmt.Errorf("cast interface to json.Number fail")
+	}
+
+	// NOTE: precision lost
+	if strings.IndexByte(n.String(), '.') != -1 {
+		value, err := n.Float64()
+		if err != nil {
+			return nil, reflect.Invalid, err
+		}
+		return value, reflect.Float64, nil
+	}
+
+	value, err := n.Int64()
+	if err != nil {
+		return nil, reflect.Invalid, err
+	}
+	return value, reflect.Int64, nil
+}
+
+func compareTwoValues(e1 interface{}, e2 interface{}, allowedComparesResults []CompareType) bool {
 	e1Kind := reflect.ValueOf(e1).Kind()
 	e2Kind := reflect.ValueOf(e2).Kind()
+
+	// if got json.Number => cast to the int64 or float64
+	if reflect.TypeOf(e1).String() == "json.Number" {
+		newE1, newE1Kind, err := castJsonNumber(e1)
+		if err == nil {
+			e1 = newE1
+			e1Kind = newE1Kind
+		}
+	}
+	if reflect.TypeOf(e2).String() == "json.Number" {
+		newE2, newE2Kind, err := castJsonNumber(e2)
+		if err == nil {
+			e2 = newE2
+			e2Kind = newE2Kind
+		}
+	}
+
+	// here, we support number types: int64/float64 compare
+	// check and cast to same type: int64 or float64 and do compare later
+	// but, here got a precision lost, which may case the eval result wrong
+	if e1Kind != e2Kind && isNumberTypes(e1) && isNumberTypes(e2) {
+		if isFloatType(e1) || isFloatType(e2) {
+			// both cast to float64
+			newE1, err := toFloat64(e1)
+			if err == nil {
+				e1 = newE1
+				e1Kind = reflect.Float64
+			}
+			newE2, err2 := toFloat64(e2)
+			if err2 == nil {
+				e2 = newE2
+				e2Kind = reflect.Float64
+			}
+		} else {
+			newE1, err := toInt64(e1)
+			if err == nil {
+				e1 = newE1
+				e1Kind = reflect.Int64
+			}
+			newE2, err2 := toInt64(e2)
+			if err2 == nil {
+				e2 = newE2
+				e2Kind = reflect.Int64
+			}
+		}
+	}
+
 	if e1Kind != e2Kind {
 		// Elements should be the same type
 		return false
@@ -397,7 +563,7 @@ func compareTwoValues(e1 interface{}, e2 interface{}, allowedComparesResults []C
 
 	if !containsValue(allowedComparesResults, compareResult) {
 		return false
-		//return Fail(t, fmt.Sprintf(failMessage, e1, e2), msgAndArgs...)
+		// return Fail(t, fmt.Sprintf(failMessage, e1, e2), msgAndArgs...)
 	}
 
 	return true

--- a/expression/eval/compare_test.go
+++ b/expression/eval/compare_test.go
@@ -158,6 +158,17 @@ var _ = Describe("Compare", func() {
 
 	})
 
+	It("ValueEquals", func() {
+		assert.True(GinkgoT(), ValueEquals("a", "a"))
+		assert.True(GinkgoT(), ValueEquals(1, 1))
+		assert.True(GinkgoT(), ValueEquals(float64(1), float64(1)))
+		assert.True(GinkgoT(), ValueEquals(float64(1), 1))
+		assert.True(GinkgoT(), ValueEquals(float64(1), json.Number("1")))
+
+		assert.False(GinkgoT(), ValueEquals(1, 2))
+		assert.False(GinkgoT(), ValueEquals("a", "b"))
+	})
+
 	It("GreaterOrEqual", func() {
 		assert.True(GinkgoT(), GreaterOrEqual(2, 1))
 		assert.True(GinkgoT(), GreaterOrEqual(1, 1))

--- a/expression/eval/compare_test.go
+++ b/expression/eval/compare_test.go
@@ -42,6 +42,7 @@ import (
 	"reflect"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -164,6 +165,7 @@ var _ = Describe("Compare", func() {
 		assert.True(GinkgoT(), ValueEquals(float64(1), float64(1)))
 		assert.True(GinkgoT(), ValueEquals(float64(1), 1))
 		assert.True(GinkgoT(), ValueEquals(float64(1), json.Number("1")))
+		assert.True(GinkgoT(), ValueEquals(json.Number("1"), json.Number("1")))
 
 		assert.False(GinkgoT(), ValueEquals(1, 2))
 		assert.False(GinkgoT(), ValueEquals("a", "b"))
@@ -253,6 +255,125 @@ var _ = Describe("Compare", func() {
 		} {
 			assert.False(GinkgoT(), LessOrEqual(currCase.greater, currCase.less))
 		}
+	})
+
+	It("isNumberKind", func() {
+		assert.True(GinkgoT(), isNumberKind(reflect.Uint))
+		assert.True(GinkgoT(), isNumberKind(reflect.Uint8))
+		assert.True(GinkgoT(), isNumberKind(reflect.Uint16))
+		assert.True(GinkgoT(), isNumberKind(reflect.Uint32))
+		assert.True(GinkgoT(), isNumberKind(reflect.Uint64))
+		assert.True(GinkgoT(), isNumberKind(reflect.Int))
+		assert.True(GinkgoT(), isNumberKind(reflect.Int8))
+		assert.True(GinkgoT(), isNumberKind(reflect.Int16))
+		assert.True(GinkgoT(), isNumberKind(reflect.Int32))
+		assert.True(GinkgoT(), isNumberKind(reflect.Int64))
+		assert.True(GinkgoT(), isNumberKind(reflect.Float32))
+		assert.True(GinkgoT(), isNumberKind(reflect.Float64))
+
+		assert.False(GinkgoT(), isNumberKind(reflect.String))
+	})
+
+	It("isFloatKind", func() {
+		assert.True(GinkgoT(), isFloatKind(reflect.Float32))
+		assert.True(GinkgoT(), isFloatKind(reflect.Float64))
+	
+		assert.False(GinkgoT(), isFloatKind(reflect.Uint))
+		assert.False(GinkgoT(), isFloatKind(reflect.Uint8))
+		assert.False(GinkgoT(), isFloatKind(reflect.Uint16))
+		assert.False(GinkgoT(), isFloatKind(reflect.Uint32))
+		assert.False(GinkgoT(), isFloatKind(reflect.Uint64))
+		assert.False(GinkgoT(), isFloatKind(reflect.Int))
+		assert.False(GinkgoT(), isFloatKind(reflect.Int8))
+		assert.False(GinkgoT(), isFloatKind(reflect.Int16))
+		assert.False(GinkgoT(), isFloatKind(reflect.Int32))
+		assert.False(GinkgoT(), isFloatKind(reflect.Int64))
+		assert.False(GinkgoT(), isFloatKind(reflect.String))
+	})
+
+	Context("toInt64", func() {
+		DescribeTable("toInt64 cases", func(expected interface{}, input interface{}, willError bool) {
+			v, err := toInt64(input)
+			if willError {
+				assert.Error(GinkgoT(), err)
+				return
+			}
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), expected, v)
+		},
+			Entry("int", int64(8), int(8), false),
+			Entry("int8", int64(8), int8(8), false),
+			Entry("int16", int64(8), int16(8), false),
+			Entry("int32", int64(8), int32(8), false),
+			Entry("int64", int64(8), int64(8), false),
+			Entry("uint", int64(8), uint(8), false),
+			Entry("uint8", int64(8), uint8(8), false),
+			Entry("uint16", int64(8), uint16(8), false),
+			Entry("uint32", int64(8), uint32(8), false),
+			Entry("uint64", int64(8), uint64(8), false),
+
+			Entry("float32", int64(0), float32(8), true),
+			Entry("float64", int64(0), float64(8.31), true),
+			Entry("string", float64(0), "8.31", true),
+		)
+
+	})
+
+	Context("toFloat64", func() {
+		DescribeTable("toFloat64 cases", func(expected interface{}, input interface{}, willError bool) {
+			v, err := toFloat64(input)
+			if willError {
+				assert.Error(GinkgoT(), err)
+				return
+			}
+			assert.NoError(GinkgoT(), err)
+			assert.Equal(GinkgoT(), expected, v)
+		},
+			Entry("int", float64(8), int(8), false),
+			Entry("int8", float64(8), int8(8), false),
+			Entry("int16", float64(8), int16(8), false),
+			Entry("int32", float64(8), int32(8), false),
+			Entry("int64", float64(8), int64(8), false),
+			Entry("uint", float64(8), uint(8), false),
+			Entry("uint8", float64(8), uint8(8), false),
+			Entry("uint16", float64(8), uint16(8), false),
+			Entry("uint32", float64(8), uint32(8), false),
+			Entry("uint64", float64(8), uint64(8), false),
+			Entry("float32", float64(8), float32(8), false),
+			Entry("float64", float64(8.31), float64(8.31), false),
+			Entry("string", float64(0), "8.31", true),
+		)
+	})
+
+	Context("castJsonNumber", func() {
+		It("type wrong", func() {
+			_, _, err := castJsonNumber(123)
+			assert.Error(GinkgoT(), err)
+		})
+
+		It("float64 ok", func() {
+			v, t, err := castJsonNumber(json.Number("123.456"))
+			assert.Equal(GinkgoT(), float64(123.456), v)
+			assert.Equal(GinkgoT(), reflect.Float64, t)
+			assert.NoError(GinkgoT(), err)
+		})
+
+		It("float64 error", func() {
+			_, _, err := castJsonNumber(json.Number("123.4abc"))
+			assert.Error(GinkgoT(), err)
+		})
+
+		It("int64 ok", func() {
+			v, t, err := castJsonNumber(json.Number("123"))
+			assert.Equal(GinkgoT(), int64(123), v)
+			assert.Equal(GinkgoT(), reflect.Int64, t)
+			assert.NoError(GinkgoT(), err)
+		})
+
+		It("int64 wrong", func() {
+			_, _, err := castJsonNumber(json.Number("abc"))
+			assert.Error(GinkgoT(), err)
+		})
 	})
 
 	Context("compareTwoValues", func() {

--- a/expression/eval/compare_test.go
+++ b/expression/eval/compare_test.go
@@ -38,6 +38,7 @@
 package eval
 
 import (
+	"encoding/json"
 	"reflect"
 
 	. "github.com/onsi/ginkgo"
@@ -94,36 +95,36 @@ var _ = Describe("Compare", func() {
 			resLess, isComparable := compare(currCase.less, currCase.greater, reflect.ValueOf(currCase.less).Kind())
 
 			assert.True(GinkgoT(), isComparable)
-			//if !isComparable {
+			// if !isComparable {
 			//	t.Error("object should be comparable for type " + currCase.cType)
-			//}
+			// }
 
 			assert.Equal(GinkgoT(), resLess, compareLess)
-			//if resLess != compareLess {
+			// if resLess != compareLess {
 			//	t.Errorf("object less should be less than greater for type " + currCase.cType)
-			//}
+			// }
 
 			resGreater, isComparable := compare(currCase.greater, currCase.less, reflect.ValueOf(currCase.less).Kind())
 			assert.True(GinkgoT(), isComparable)
-			//if !isComparable {
+			// if !isComparable {
 			//	t.Error("object are comparable for type " + currCase.cType)
-			//}
+			// }
 
 			assert.Equal(GinkgoT(), resGreater, compareGreater)
-			//if resGreater != compareGreater {
+			// if resGreater != compareGreater {
 			//	t.Errorf("object greater should be greater than less for type " + currCase.cType)
-			//}
+			// }
 
 			resEqual, isComparable := compare(currCase.less, currCase.less, reflect.ValueOf(currCase.less).Kind())
 			assert.True(GinkgoT(), isComparable)
-			//if !isComparable {
+			// if !isComparable {
 			//	t.Error("object are comparable for type " + currCase.cType)
-			//}
+			// }
 
 			assert.Equal(GinkgoT(), resEqual, compareEqual)
-			//if resEqual != 0 {
+			// if resEqual != 0 {
 			//	t.Errorf("objects should be equal for type " + currCase.cType)
-			//}
+			// }
 		}
 
 	})
@@ -295,6 +296,81 @@ var _ = Describe("Compare", func() {
 				assert.True(GinkgoT(), compareResult)
 			}
 
+		})
+
+		It("compareTwoValues, no same type, int, ok", func() {
+			for _, currCase := range []struct {
+				v1           interface{}
+				v2           interface{}
+				compareTypes []CompareType
+			}{
+				{v1: 1, v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: int(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: int64(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: int32(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: int16(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: int8(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: uint(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: uint64(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: uint32(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: uint16(2), compareTypes: []CompareType{compareLess}},
+				{v1: 1, v2: uint8(2), compareTypes: []CompareType{compareLess}},
+				{v1: int(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: int64(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: int32(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: int16(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: int8(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: uint(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: uint64(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: uint32(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: uint16(1), v2: 2, compareTypes: []CompareType{compareLess}},
+				{v1: uint8(1), v2: 2, compareTypes: []CompareType{compareLess}},
+			} {
+				compareResult := compareTwoValues(currCase.v1, currCase.v2, currCase.compareTypes)
+				assert.True(GinkgoT(), compareResult)
+			}
+
+		})
+
+		It("compareTwoValues, no same type, float, ok", func() {
+			for _, currCase := range []struct {
+				v1           interface{}
+				v2           interface{}
+				compareTypes []CompareType
+			}{
+				{v1: int(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: int64(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: int32(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: int16(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: int8(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: uint(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: uint64(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: uint32(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: uint16(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+				{v1: uint8(1), v2: 2.1, compareTypes: []CompareType{compareLess}},
+
+				{v1: int(1), v2: float32(2.1), compareTypes: []CompareType{compareLess}},
+				{v1: int(1), v2: float64(2.1), compareTypes: []CompareType{compareLess}},
+				{v1: float32(1.1), v2: float64(2.1), compareTypes: []CompareType{compareLess}},
+			} {
+				compareResult := compareTwoValues(currCase.v1, currCase.v2, currCase.compareTypes)
+				assert.True(GinkgoT(), compareResult)
+			}
+		})
+
+		It("compareTwoValues, json.Number, ok", func() {
+			for _, currCase := range []struct {
+				v1           interface{}
+				v2           interface{}
+				compareTypes []CompareType
+			}{
+				{v1: int(1), v2: json.Number("2"), compareTypes: []CompareType{compareLess}},
+				{v1: int(1), v2: json.Number("2.1"), compareTypes: []CompareType{compareLess}},
+				{v1: json.Number("1"), v2: json.Number("2.1"), compareTypes: []CompareType{compareLess}},
+			} {
+				compareResult := compareTwoValues(currCase.v1, currCase.v2, currCase.compareTypes)
+				assert.True(GinkgoT(), compareResult)
+			}
 		})
 
 	})

--- a/expression/expr_test.go
+++ b/expression/expr_test.go
@@ -12,6 +12,7 @@
 package expression_test
 
 import (
+	"encoding/json"
 	"strconv"
 	"testing"
 
@@ -52,7 +53,7 @@ var _ = Describe("Expr", func() {
 			// String
 			assert.Equal(GinkgoT(), "((obj.id eq 1) AND (obj.name eq object))", e.String())
 
-			//hit
+			// hit
 			o.Set("obj", map[string]interface{}{
 				"id":   1,
 				"name": "object",
@@ -62,7 +63,7 @@ var _ = Describe("Expr", func() {
 			// Render
 			assert.Equal(GinkgoT(), "((1 eq 1) AND (object eq object))", e.Render(o))
 
-			//miss
+			// miss
 			o.Set("obj", map[string]interface{}{
 				"id":   2,
 				"name": "object",
@@ -91,7 +92,7 @@ var _ = Describe("Expr", func() {
 			// String
 			assert.Equal(GinkgoT(), "((obj.id eq 1) OR (obj.name eq object))", e.String())
 
-			//hit
+			// hit
 			o.Set("obj", map[string]interface{}{
 				"id":   1,
 				"name": "object1",
@@ -101,7 +102,7 @@ var _ = Describe("Expr", func() {
 			// Render
 			assert.Equal(GinkgoT(), "((1 eq 1) OR (object1 eq object))", e.Render(o))
 
-			//miss
+			// miss
 			o.Set("obj", map[string]interface{}{
 				"id":   2,
 				"name": "object2",
@@ -506,6 +507,46 @@ func BenchmarkExprCellLess(b *testing.B) {
 		e.Eval(o)
 	}
 }
+func BenchmarkExprCellLessDifferentType(b *testing.B) {
+	e := &expression.ExprCell{
+		OP:    operator.Lt,
+		Field: "obj.age",
+		Value: float32(18),
+	}
+
+	o := expression.NewObjectSet()
+	o.Set("obj", map[string]interface{}{
+		"name": "helloworld",
+		"age":  int64(2),
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Eval(o)
+	}
+}
+
+func BenchmarkExprCellLessDifferentTypeJsonNumber(b *testing.B) {
+	e := &expression.ExprCell{
+		OP:    operator.Lt,
+		Field: "obj.age",
+		Value: json.Number("18"),
+	}
+
+	o := expression.NewObjectSet()
+	o.Set("obj", map[string]interface{}{
+		"name": "helloworld",
+		"age":  2,
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Eval(o)
+	}
+}
+
 func BenchmarkExprCellStartsWith(b *testing.B) {
 	e := &expression.ExprCell{
 		OP:    operator.StartsWith,

--- a/release.md
+++ b/release.md
@@ -1,6 +1,11 @@
 版本日志
 ===============
 
+## IAM v0.0.6
+
+- [NEW] 支持不同类型数值比较
+- [NEW] 增加ValueEquals, 用于不同类型数值比较(原 Equals 只支持相同类型对象比较)
+
 ## IAM v0.0.5
 
 - [NEW] support call apis via APIGateway

--- a/version.go
+++ b/version.go
@@ -11,4 +11,4 @@
 
 package iam
 
-const Version = "v0.0.5"
+const Version = "v0.0.6"


### PR DESCRIPTION
- 支持不同类型数值比较
- 增加ValueEquals, 用于不同类型数值比较(原 Equals 只支持相同类型对象比较)
- 注意: 暂时没有处理转换时的精度损失